### PR TITLE
Fixes data validation issues in Util::subUrl.

### DIFF
--- a/lib/Core/Util.php
+++ b/lib/Core/Util.php
@@ -69,7 +69,14 @@ abstract class Util
     public static function subUrl($url, $substitutions)
     {
         foreach ($substitutions as $substitution_key => $substitution_value) {
-            if (!is_string($substitution_value)) {
+            // @note Eager version of the 'or' operator (|) is used
+            // intentionally in the condition below.
+            if (false === is_scalar($substitution_value)
+                | is_array($substitution_value)
+                | is_object($substitution_value)
+                | is_object($substitution_value) && false === method_exists($substitution_value, '__toString')
+                | is_resource($substitution_value)
+            ) {
                 $error_type = ' needs to be a string, not a '.gettype($substitution_value).'.';
                 throw new \Exception('URL value for ' . $substitution_key . $error_type);
             }

--- a/tests/Core/UtilsTest.php
+++ b/tests/Core/UtilsTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace GoCardlessPro\Core;
+
+class UtilsTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStringsCanBeBoundAsUrlParameters()
+    {
+        $this->assertEquals(
+            '/me',
+            Util::subUrl('/:replace-me', ['replace-me' => 'me'])
+        );
+    }
+
+    public function testIntegersCanBeBoundAsUrlParameters()
+    {
+        $this->assertEquals(
+            '/1',
+            Util::subUrl('/:replace-me', ['replace-me' => 1])
+        );
+    }
+
+    public function testFloatsCanBeBoundAsUrlParameters()
+    {
+        $this->assertEquals(
+            '/3.14',
+            Util::subUrl('/:replace-me', ['replace-me' => (float) 3.14])
+        );
+    }
+
+    public function testDoublesCanBeBoundAsUrlParameters()
+    {
+        $this->assertEquals(
+            '/3.14',
+            Util::subUrl('/:replace-me', ['replace-me' => (double) 3.14])
+        );
+    }
+
+    public function testToStringObjectsCanBeBoundAsUrlParameters()
+    {
+        $this->assertEquals(
+            '/test',
+            Util::subUrl('/:replace-me', ['replace-me' => $this])
+        );
+    }
+
+    public function testArraysCannotBeBoundAsUrlParameters()
+    {
+        $this->setExpectedException('Exception');
+        Util::subUrl('/:replace-me', ['replace-me' => ['hello' => 'world']]);
+    }
+
+    public function testObjectsCannotBeBoundAsUrlParameters()
+    {
+        $this->setExpectedException('Exception');
+        Util::subUrl('/:replace-me', ['replace-me' => (object) ['hello' => 'world']]);
+    }
+
+    public function testResourcesCannotBeBoundAsUrlParameters()
+    {
+        $this->setExpectedException('Exception');
+        $stream = fopen('php://stderr', 'r');
+        try {
+            Util::subUrl('/:replace-me', ['replace-me' => $stream]);
+        } finally {
+            fclose($stream);
+        }
+    }
+
+    public function __toString()
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
Everything must be explicitly casted into a string before passing it to many of the GoCardless pro PHP client. This is rather unpleasant thing to do in a language with dynamic typing.

The proposed changes will allow the following data types to treated as strings, so the client doesn't throw an unnecessary validation exception:
- strings.
- numbers (integers, floats, doubles).
- objects with a `__toString` method.

The following data types are rejected by the validation:
- arrays
- resources
- objects that can't be cast to strings.
- any other type the PHP type system doesn't consider a scalar.

I understand raising a PR isn't the best way to provide your library with a fix, so feel free to download [patch here](https://github.com/gocardless/gocardless-pro-php/compare/master...trashofmasters:master.patch), and close this request accordingly.
