### PR TITLE
Add null to resolve potential type error in Retry Middleware

### DIFF
--- a/lib/RetryMiddlewareFactory.php
+++ b/lib/RetryMiddlewareFactory.php
@@ -85,7 +85,7 @@ class RetryMiddlewareFactory
      * Timeout)
      * @return boolean
      */
-    private static function isRetryableServerError(\GuzzleHttp\Psr7\Response $response)
+    private static function isRetryableServerError(\GuzzleHttp\Psr7\Response $response = null)
     {
         if ($response) {
             $statusCode = $response->getStatusCode();


### PR DESCRIPTION
Fix potential type error where null is accepted for the value of a variable by the caller but the method being called does not accept null.

The method `buildRetryDecider` returns a callback where the `$response` variable can be null. The path then has potential to call `static::isRetryableServerError` which accepts a `$response` of the same type but which is specified as _not null_. Therefore if the call is null a `TypeError` is thrown when checking if the error is retryable.

Also interesting to note, we've only just started seeing these which suggests we're getting timeouts where previously we didn't have them (i.e. that's why `$response` is null). I will pass this separately to the API team as I imagine it to be an ops issue.