### PR TITLE
Fix wrong order in implode() call

### DIFF
--- a/lib/Core/Exception/ApiException.php
+++ b/lib/Core/Exception/ApiException.php
@@ -81,7 +81,7 @@ class ApiException extends GoCardlessProException
         );
 
         if (count($error_messages) > 0) {
-            return $this->api_error->message . ' (' . implode($error_messages, ", ") . ')';
+            return $this->api_error->message . ' (' . implode(", ", $error_messages) . ')';
         } else {
             return $this->api_error->message;
         }


### PR DESCRIPTION
In PHP 7.4 this leads to a "implode(): Passing glue string after array is deprecated. Swap the parameters" notice.