### PR TITLE
Fixes namespace phpdoc

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -22,9 +22,9 @@ class Webhook
      *                                         `Webhook-Signature` header
      * @param  string $webhook_endpoint_secret the webhook endpoint secret for your webhook
      *                                         endpoint, as configured in your GoCardless Dashboard
-     * @return GoCardlessPro\Resources\Event[] the events included in the
+     * @return \GoCardlessPro\Resources\Event[] the events included in the
      *     webhook
-     * @raises GoCardlessPro\Core\Exception\InvalidSignatureException if the
+     * @raises \GoCardlessPro\Core\Exception\InvalidSignatureException if the
      *     signature header specified does not match the signature computed using the
      *     request body and webhook endpoint secret
      */


### PR DESCRIPTION
Fix namespace phpdoc for parse() method, and make them absolute, to avoid issues with detecting the return type using IDEs