### PR TITLE
php 7.4 compatibility

### DIFF
--- a/lib/Core/Exception/ApiException.php
+++ b/lib/Core/Exception/ApiException.php
@@ -81,7 +81,7 @@ class ApiException extends GoCardlessProException
         );
 
         if (count($error_messages) > 0) {
-            return $this->api_error->message . ' (' . implode(", ", $error_messages) . ')';
+            return $this->api_error->message . ' (' . implode($error_messages, ", ") . ')';
         } else {
             return $this->api_error->message;
         }


### PR DESCRIPTION
Hello, with PHP 7.4 parameter's order accepted by implode function must be array / separator. It doesn't break backward compatibility with previous PHP version

https://www.php.net/manual/en/function.implode.php