### PR TITLE
Allow NULL as valid parameter for isRetryableServerError

### DIFF
--- a/lib/RetryMiddlewareFactory.php
+++ b/lib/RetryMiddlewareFactory.php
@@ -90,7 +90,7 @@ class RetryMiddlewareFactory
      *
      * @return boolean
      */
-    private static function isRetryableServerError(\GuzzleHttp\Psr7\Response $response = null)
+    private static function isRetryableServerError(?\GuzzleHttp\Psr7\Response $response = null)
     {
         if ($response) {
             $statusCode = $response->getStatusCode();


### PR DESCRIPTION
When there was a server error that caused GoCardless API requests to fail, the GC library was failing to handle the error correctly due to a mistake in the function signature.

I was getting errors like this:

> PHP Fatal error:  Uncaught TypeError: Argument 1 passed to GoCardlessPro\RetryMiddlewareFactory::isRetryableServerError() must be an instance of GuzzleHttp\Psr7\Response, null given, called in vendor/gocardless/gocardless-pro/lib/RetryMiddlewareFactory.php on line 40 and defined in vendor/gocardless/gocardless-pro/lib/RetryMiddlewareFactory.php:88

The problem was that calling that method with an argument whose value is NULL is not allowed by the function signature.

This PR adds a ? before the type hint, which fixes the problem, the code is now valid and when circumstances arise (like network failures) the error can be properly handled and reported.
