### PR TITLE
Skip exporting unneeded files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.circleci/        export-ignore
+.gitattributes     export-ignore
+.gitignore         export-ignore
+/Makefile          export-ignore
+/phpcs-ruleset.xml export-ignore
+/phpunit.xml       export-ignore
+/tests/            export-ignore


### PR DESCRIPTION
To keep test files and other things out of the packaged build.