### PR TITLE
Fix deprecation notice for PHP 8.2.*

### DIFF
--- a/lib/Webhook.php
+++ b/lib/Webhook.php
@@ -32,7 +32,9 @@ class Webhook
     {
         if (self::isSignatureValid($request_body, $signature_header, $webhook_endpoint_secret)) {
             $events = json_decode($request_body)->events;
-            return array_map('self::buildEvent', $events);
+            return array_map(function($event) {
+                return self::buildEvent($event);
+            }, $events);
         } else {
             throw new Core\Exception\InvalidSignatureException(self::INVALID_SIGNATURE_MESSAGE);
         }


### PR DESCRIPTION
Callables that are not accepted by the $callable() syntax (but are accepted by call_user_func()) are deprecated. https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.relative-callables