### PR TITLE
Resolve 'creation of dynamic propery' on Core\ApiClient

### DIFF
--- a/lib/Core/ApiClient.php
+++ b/lib/Core/ApiClient.php
@@ -15,6 +15,9 @@ use GoCardlessPro\Core\Exception\ApiException;
  */
 class ApiClient
 {
+    public $http_client;
+    public $error_on_idempotency_conflict;
+    
     /**
      * @param GuzzleHttp\ClientInterface $http_client An HTTP client to make requests
      * @param array                      $config      configuration for the ApiClient


### PR DESCRIPTION
Resolve issues exposed by deprecated messages introduced on PHP8.2 which indicate future breaking changes on the next major release cycle.

- `Deprecated: Creation of dynamic property GoCardlessPro\Core\ApiClient::$error_on_idempotency_conflict is deprecated in /<secret_project>/vendor/gocardless/gocardless-pro/lib/Core/ApiClient.php on line 28`
- `Deprecated: Creation of dynamic property GoCardlessPro\Core\ApiClient::$http_client is deprecated in /<secret_project>/vendor/gocardless/gocardless-pro/lib/Core/ApiClient.php on line 27`