### PR TITLE
Fix for PHP 8.2 Dynamic Properties

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -1,10 +1,12 @@
 <?php
 
 namespace GoCardlessPro;
+use \AllowDynamicProperties;
 
 /**
  * Main GoCardlessPro Client for making API calls
  */
+#[AllowDynamicProperties]
 class Client
 {
 

--- a/lib/Core/ApiClient.php
+++ b/lib/Core/ApiClient.php
@@ -7,12 +7,15 @@
 
 namespace GoCardlessPro\Core;
 
+use \AllowDynamicProperties;
+
 use GoCardlessPro\Core\Exception\ApiException;
 
 /**
  * HTTP Client class wrapped by the Client class and
  * used internally to route http requests.
  */
+#[AllowDynamicProperties]
 class ApiClient
 {
     /**


### PR DESCRIPTION
Dynamic properties are deprecated in PHP 8.2.

Added #[AllowDynamicProperties].

See: https://php.watch/versions/8.2/dynamic-properties-deprecated