### PR TITLE
Fix phpdoc

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -71,76 +71,76 @@ class Client
         $this->api_client = new \GoCardlessPro\Core\ApiClient($http_client, $config);
 
         // Instantiate the services for each property
-        
+
         $this->services['bank_authorisations'] = new Services\BankAuthorisationsService($this->api_client);
-        
+
         $this->services['bank_details_lookups'] = new Services\BankDetailsLookupsService($this->api_client);
-        
+
         $this->services['billing_requests'] = new Services\BillingRequestsService($this->api_client);
-        
+
         $this->services['billing_request_flows'] = new Services\BillingRequestFlowsService($this->api_client);
-        
+
         $this->services['billing_request_templates'] = new Services\BillingRequestTemplatesService($this->api_client);
-        
+
         $this->services['blocks'] = new Services\BlocksService($this->api_client);
-        
+
         $this->services['creditors'] = new Services\CreditorsService($this->api_client);
-        
+
         $this->services['creditor_bank_accounts'] = new Services\CreditorBankAccountsService($this->api_client);
-        
+
         $this->services['currency_exchange_rates'] = new Services\CurrencyExchangeRatesService($this->api_client);
-        
+
         $this->services['customers'] = new Services\CustomersService($this->api_client);
-        
+
         $this->services['customer_bank_accounts'] = new Services\CustomerBankAccountsService($this->api_client);
-        
+
         $this->services['customer_notifications'] = new Services\CustomerNotificationsService($this->api_client);
-        
+
         $this->services['events'] = new Services\EventsService($this->api_client);
-        
+
         $this->services['instalment_schedules'] = new Services\InstalmentSchedulesService($this->api_client);
-        
+
         $this->services['institutions'] = new Services\InstitutionsService($this->api_client);
-        
+
         $this->services['mandates'] = new Services\MandatesService($this->api_client);
-        
+
         $this->services['mandate_imports'] = new Services\MandateImportsService($this->api_client);
-        
+
         $this->services['mandate_import_entries'] = new Services\MandateImportEntriesService($this->api_client);
-        
+
         $this->services['mandate_pdfs'] = new Services\MandatePdfsService($this->api_client);
-        
+
         $this->services['negative_balance_limits'] = new Services\NegativeBalanceLimitsService($this->api_client);
-        
+
         $this->services['payer_authorisations'] = new Services\PayerAuthorisationsService($this->api_client);
-        
+
         $this->services['payments'] = new Services\PaymentsService($this->api_client);
-        
+
         $this->services['payouts'] = new Services\PayoutsService($this->api_client);
-        
+
         $this->services['payout_items'] = new Services\PayoutItemsService($this->api_client);
-        
+
         $this->services['redirect_flows'] = new Services\RedirectFlowsService($this->api_client);
-        
+
         $this->services['refunds'] = new Services\RefundsService($this->api_client);
-        
+
         $this->services['scenario_simulators'] = new Services\ScenarioSimulatorsService($this->api_client);
-        
+
         $this->services['scheme_identifiers'] = new Services\SchemeIdentifiersService($this->api_client);
-        
+
         $this->services['subscriptions'] = new Services\SubscriptionsService($this->api_client);
-        
+
         $this->services['tax_rates'] = new Services\TaxRatesService($this->api_client);
-        
+
         $this->services['transferred_mandates'] = new Services\TransferredMandatesService($this->api_client);
-        
+
         $this->services['verification_details'] = new Services\VerificationDetailsService($this->api_client);
-        
+
         $this->services['webhooks'] = new Services\WebhooksService($this->api_client);
-        
+
     }
 
-    
+
     /**
      * Service for interacting with bank authorisations
      *
@@ -153,7 +153,7 @@ class Client
         }
         return $this->services['bank_authorisations'];
     }
-    
+
     /**
      * Service for interacting with bank details lookups
      *
@@ -166,7 +166,7 @@ class Client
         }
         return $this->services['bank_details_lookups'];
     }
-    
+
     /**
      * Service for interacting with billing requests
      *
@@ -179,7 +179,7 @@ class Client
         }
         return $this->services['billing_requests'];
     }
-    
+
     /**
      * Service for interacting with billing request flows
      *
@@ -192,7 +192,7 @@ class Client
         }
         return $this->services['billing_request_flows'];
     }
-    
+
     /**
      * Service for interacting with billing request templates
      *
@@ -205,7 +205,7 @@ class Client
         }
         return $this->services['billing_request_templates'];
     }
-    
+
     /**
      * Service for interacting with blocks
      *
@@ -218,7 +218,7 @@ class Client
         }
         return $this->services['blocks'];
     }
-    
+
     /**
      * Service for interacting with creditors
      *
@@ -231,7 +231,7 @@ class Client
         }
         return $this->services['creditors'];
     }
-    
+
     /**
      * Service for interacting with creditor bank accounts
      *
@@ -244,7 +244,7 @@ class Client
         }
         return $this->services['creditor_bank_accounts'];
     }
-    
+
     /**
      * Service for interacting with currency exchange rates
      *
@@ -257,7 +257,7 @@ class Client
         }
         return $this->services['currency_exchange_rates'];
     }
-    
+
     /**
      * Service for interacting with customers
      *
@@ -270,7 +270,7 @@ class Client
         }
         return $this->services['customers'];
     }
-    
+
     /**
      * Service for interacting with customer bank accounts
      *
@@ -283,7 +283,7 @@ class Client
         }
         return $this->services['customer_bank_accounts'];
     }
-    
+
     /**
      * Service for interacting with customer notifications
      *
@@ -296,7 +296,7 @@ class Client
         }
         return $this->services['customer_notifications'];
     }
-    
+
     /**
      * Service for interacting with events
      *
@@ -309,7 +309,7 @@ class Client
         }
         return $this->services['events'];
     }
-    
+
     /**
      * Service for interacting with instalment schedule
      *
@@ -322,7 +322,7 @@ class Client
         }
         return $this->services['instalment_schedules'];
     }
-    
+
     /**
      * Service for interacting with institutions
      *
@@ -335,7 +335,7 @@ class Client
         }
         return $this->services['institutions'];
     }
-    
+
     /**
      * Service for interacting with mandates
      *
@@ -348,7 +348,7 @@ class Client
         }
         return $this->services['mandates'];
     }
-    
+
     /**
      * Service for interacting with mandate imports
      *
@@ -361,7 +361,7 @@ class Client
         }
         return $this->services['mandate_imports'];
     }
-    
+
     /**
      * Service for interacting with mandate import entries
      *
@@ -374,7 +374,7 @@ class Client
         }
         return $this->services['mandate_import_entries'];
     }
-    
+
     /**
      * Service for interacting with mandate pdfs
      *
@@ -387,7 +387,7 @@ class Client
         }
         return $this->services['mandate_pdfs'];
     }
-    
+
     /**
      * Service for interacting with negative balance limit
      *
@@ -400,7 +400,7 @@ class Client
         }
         return $this->services['negative_balance_limits'];
     }
-    
+
     /**
      * Service for interacting with payer authorisations
      *
@@ -413,7 +413,7 @@ class Client
         }
         return $this->services['payer_authorisations'];
     }
-    
+
     /**
      * Service for interacting with payments
      *
@@ -426,7 +426,7 @@ class Client
         }
         return $this->services['payments'];
     }
-    
+
     /**
      * Service for interacting with payouts
      *
@@ -439,7 +439,7 @@ class Client
         }
         return $this->services['payouts'];
     }
-    
+
     /**
      * Service for interacting with payout items
      *
@@ -452,7 +452,7 @@ class Client
         }
         return $this->services['payout_items'];
     }
-    
+
     /**
      * Service for interacting with redirect flows
      *
@@ -465,7 +465,7 @@ class Client
         }
         return $this->services['redirect_flows'];
     }
-    
+
     /**
      * Service for interacting with refunds
      *
@@ -478,7 +478,7 @@ class Client
         }
         return $this->services['refunds'];
     }
-    
+
     /**
      * Service for interacting with scenario simulators
      *
@@ -491,7 +491,7 @@ class Client
         }
         return $this->services['scenario_simulators'];
     }
-    
+
     /**
      * Service for interacting with scheme identifiers
      *
@@ -504,7 +504,7 @@ class Client
         }
         return $this->services['scheme_identifiers'];
     }
-    
+
     /**
      * Service for interacting with subscriptions
      *
@@ -517,7 +517,7 @@ class Client
         }
         return $this->services['subscriptions'];
     }
-    
+
     /**
      * Service for interacting with tax rates
      *
@@ -530,7 +530,7 @@ class Client
         }
         return $this->services['tax_rates'];
     }
-    
+
     /**
      * Service for interacting with transferred mandate
      *
@@ -543,7 +543,7 @@ class Client
         }
         return $this->services['transferred_mandates'];
     }
-    
+
     /**
      * Service for interacting with verification details
      *
@@ -556,7 +556,7 @@ class Client
         }
         return $this->services['verification_details'];
     }
-    
+
     /**
      * Service for interacting with webhooks
      *
@@ -569,7 +569,7 @@ class Client
         }
         return $this->services['webhooks'];
     }
-    
+
     private function getUrlForEnvironment($environment)
     {
         $environment_urls = array(
@@ -587,7 +587,7 @@ class Client
     /**
      * Ensures a config is valid and sets defaults where required
      *
-     * @param array[string]mixed $config the client configuration options
+     * @param array<string, mixed> $config the client configuration options
      */
     private function validate_config(&$config)
     {

--- a/lib/Services/BankAuthorisationsService.php
+++ b/lib/Services/BankAuthorisationsService.php
@@ -17,9 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the BankAuthorisation
  * endpoints of the API
- *
- * @method create()
- * @method get()
  */
 class BankAuthorisationsService extends BaseService
 {
@@ -33,19 +30,19 @@ class BankAuthorisationsService extends BaseService
      *
      * Example URL: /bank_authorisations
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return BankAuthorisation
      **/
     public function create($params = array())
     {
         $path = "/bank_authorisations";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -58,7 +55,7 @@ class BankAuthorisationsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -69,7 +66,7 @@ class BankAuthorisationsService extends BaseService
      * Example URL: /bank_authorisations/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BAU".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BankAuthorisation
      **/
     public function get($identity, $params = array())
@@ -77,7 +74,7 @@ class BankAuthorisationsService extends BaseService
         $path = Util::subUrl(
             '/bank_authorisations/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -85,9 +82,9 @@ class BankAuthorisationsService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/BankDetailsLookupsService.php
+++ b/lib/Services/BankDetailsLookupsService.php
@@ -17,8 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the BankDetailsLookup
  * endpoints of the API
- *
- * @method create()
  */
 class BankDetailsLookupsService extends BaseService
 {
@@ -32,21 +30,21 @@ class BankDetailsLookupsService extends BaseService
      *
      * Example URL: /bank_details_lookups
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return BankDetailsLookup
      **/
     public function create($params = array())
     {
         $path = "/bank_details_lookups";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->post($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/BillingRequestFlowsService.php
+++ b/lib/Services/BillingRequestFlowsService.php
@@ -17,9 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the BillingRequestFlow
  * endpoints of the API
- *
- * @method create()
- * @method initialise()
  */
 class BillingRequestFlowsService extends BaseService
 {
@@ -33,21 +30,21 @@ class BillingRequestFlowsService extends BaseService
      *
      * Example URL: /billing_request_flows
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return BillingRequestFlow
      **/
     public function create($params = array())
     {
         $path = "/billing_request_flows";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->post($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -58,7 +55,7 @@ class BillingRequestFlowsService extends BaseService
      * Example URL: /billing_request_flows/:identity/actions/initialise
      *
      * @param  string        $identity Unique identifier, beginning with "BRF".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequestFlow
      **/
     public function initialise($identity, $params = array())
@@ -66,19 +63,19 @@ class BillingRequestFlowsService extends BaseService
         $path = Util::subUrl(
             '/billing_request_flows/:identity/actions/initialise',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->post($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/BillingRequestTemplatesService.php
+++ b/lib/Services/BillingRequestTemplatesService.php
@@ -18,10 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the BillingRequestTemplate
  * endpoints of the API
  *
- * @method list()
- * @method get()
- * @method create()
- * @method update()
+ * @method ListResponse list(array $params)
  */
 class BillingRequestTemplatesService extends BaseService
 {
@@ -35,7 +32,7 @@ class BillingRequestTemplatesService extends BaseService
      *
      * Example URL: /billing_request_templates
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -58,7 +55,7 @@ class BillingRequestTemplatesService extends BaseService
      * Example URL: /billing_request_templates/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BRT".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequestTemplate
      **/
     public function get($identity, $params = array())
@@ -86,7 +83,7 @@ class BillingRequestTemplatesService extends BaseService
      *
      * Example URL: /billing_request_templates
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return BillingRequestTemplate
      **/
     public function create($params = array())
@@ -122,7 +119,7 @@ class BillingRequestTemplatesService extends BaseService
      * Example URL: /billing_request_templates/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequestTemplate
      **/
     public function update($identity, $params = array())
@@ -152,7 +149,7 @@ class BillingRequestTemplatesService extends BaseService
      *
      * Example URL: /billing_request_templates
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/BillingRequestsService.php
+++ b/lib/Services/BillingRequestsService.php
@@ -18,18 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the BillingRequest
  * endpoints of the API
  *
- * @method create()
- * @method collectCustomerDetails()
- * @method collectBankAccount()
- * @method confirmPayerDetails()
- * @method fulfil()
- * @method cancel()
- * @method list()
- * @method get()
- * @method notify()
- * @method fallback()
- * @method chooseCurrency()
- * @method selectInstitution()
+ * @method ListResponse list(array $params)
  */
 class BillingRequestsService extends BaseService
 {
@@ -43,19 +32,19 @@ class BillingRequestsService extends BaseService
      *
      * Example URL: /billing_requests
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return BillingRequest
      **/
     public function create($params = array())
     {
         $path = "/billing_requests";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -68,7 +57,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -79,7 +68,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/collect_customer_details
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function collectCustomerDetails($identity, $params = array())
@@ -87,17 +76,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/collect_customer_details',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -110,7 +99,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -121,7 +110,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/collect_bank_account
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function collectBankAccount($identity, $params = array())
@@ -129,17 +118,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/collect_bank_account',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -152,7 +141,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -163,7 +152,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/confirm_payer_details
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function confirmPayerDetails($identity, $params = array())
@@ -171,17 +160,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/confirm_payer_details',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -194,7 +183,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -205,7 +194,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/fulfil
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function fulfil($identity, $params = array())
@@ -213,17 +202,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/fulfil',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -236,7 +225,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -247,7 +236,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/cancel
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function cancel($identity, $params = array())
@@ -255,17 +244,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/cancel',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -278,7 +267,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -288,7 +277,7 @@ class BillingRequestsService extends BaseService
      *
      * Example URL: /billing_requests
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -298,9 +287,9 @@ class BillingRequestsService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -311,7 +300,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function get($identity, $params = array())
@@ -319,7 +308,7 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -327,9 +316,9 @@ class BillingRequestsService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -340,7 +329,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/notify
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function notify($identity, $params = array())
@@ -348,17 +337,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/notify',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -371,7 +360,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -382,7 +371,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/fallback
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function fallback($identity, $params = array())
@@ -390,17 +379,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/fallback',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -413,7 +402,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -424,7 +413,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/choose_currency
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function chooseCurrency($identity, $params = array())
@@ -432,17 +421,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/choose_currency',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -455,7 +444,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -466,7 +455,7 @@ class BillingRequestsService extends BaseService
      * Example URL: /billing_requests/:identity/actions/select_institution
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return BillingRequest
      **/
     public function selectInstitution($identity, $params = array())
@@ -474,17 +463,17 @@ class BillingRequestsService extends BaseService
         $path = Util::subUrl(
             '/billing_requests/:identity/actions/select_institution',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -497,7 +486,7 @@ class BillingRequestsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -507,7 +496,7 @@ class BillingRequestsService extends BaseService
      *
      * Example URL: /billing_requests
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/BlocksService.php
+++ b/lib/Services/BlocksService.php
@@ -18,12 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Block
  * endpoints of the API
  *
- * @method create()
- * @method get()
- * @method list()
- * @method disable()
- * @method enable()
- * @method blockByRef()
+ * @method ListResponse list(array $params)
  */
 class BlocksService extends BaseService
 {
@@ -37,7 +32,7 @@ class BlocksService extends BaseService
      *
      * Example URL: /blocks
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Block
      **/
     public function create($params = array())
@@ -73,7 +68,7 @@ class BlocksService extends BaseService
      * Example URL: /blocks/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BLC".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Block
      **/
     public function get($identity, $params = array())
@@ -101,7 +96,7 @@ class BlocksService extends BaseService
      *
      * Example URL: /blocks
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -124,7 +119,7 @@ class BlocksService extends BaseService
      * Example URL: /blocks/:identity/actions/disable
      *
      * @param  string        $identity Unique identifier, beginning with "BLC".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Block
      **/
     public function disable($identity, $params = array())
@@ -166,7 +161,7 @@ class BlocksService extends BaseService
      * Example URL: /blocks/:identity/actions/enable
      *
      * @param  string        $identity Unique identifier, beginning with "BLC".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Block
      **/
     public function enable($identity, $params = array())
@@ -207,7 +202,7 @@ class BlocksService extends BaseService
      *
      * Example URL: /blocks/block_by_ref
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     public function blockByRef($params = array())
@@ -242,7 +237,7 @@ class BlocksService extends BaseService
      *
      * Example URL: /blocks
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/CreditorBankAccountsService.php
+++ b/lib/Services/CreditorBankAccountsService.php
@@ -18,10 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the CreditorBankAccount
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method disable()
+ * @method ListResponse list(array $params)
  */
 class CreditorBankAccountsService extends BaseService
 {
@@ -35,7 +32,7 @@ class CreditorBankAccountsService extends BaseService
      *
      * Example URL: /creditor_bank_accounts
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return CreditorBankAccount
      **/
     public function create($params = array())
@@ -70,7 +67,7 @@ class CreditorBankAccountsService extends BaseService
      *
      * Example URL: /creditor_bank_accounts
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -93,7 +90,7 @@ class CreditorBankAccountsService extends BaseService
      * Example URL: /creditor_bank_accounts/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return CreditorBankAccount
      **/
     public function get($identity, $params = array())
@@ -122,7 +119,7 @@ class CreditorBankAccountsService extends BaseService
      * Example URL: /creditor_bank_accounts/:identity/actions/disable
      *
      * @param  string        $identity Unique identifier, beginning with "BA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return CreditorBankAccount
      **/
     public function disable($identity, $params = array())
@@ -163,7 +160,7 @@ class CreditorBankAccountsService extends BaseService
      *
      * Example URL: /creditor_bank_accounts
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/CreditorsService.php
+++ b/lib/Services/CreditorsService.php
@@ -18,10 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Creditor
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
+ * @method ListResponse list(array $params)
  */
 class CreditorsService extends BaseService
 {
@@ -35,7 +32,7 @@ class CreditorsService extends BaseService
      *
      * Example URL: /creditors
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Creditor
      **/
     public function create($params = array())
@@ -70,7 +67,7 @@ class CreditorsService extends BaseService
      *
      * Example URL: /creditors
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -93,7 +90,7 @@ class CreditorsService extends BaseService
      * Example URL: /creditors/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "CR".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Creditor
      **/
     public function get($identity, $params = array())
@@ -122,7 +119,7 @@ class CreditorsService extends BaseService
      * Example URL: /creditors/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "CR".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Creditor
      **/
     public function update($identity, $params = array())
@@ -152,7 +149,7 @@ class CreditorsService extends BaseService
      *
      * Example URL: /creditors
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/CurrencyExchangeRatesService.php
+++ b/lib/Services/CurrencyExchangeRatesService.php
@@ -18,7 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the CurrencyExchangeRate
  * endpoints of the API
  *
- * @method list()
+ * @method ListResponse list(array $params)
  */
 class CurrencyExchangeRatesService extends BaseService
 {
@@ -32,7 +32,7 @@ class CurrencyExchangeRatesService extends BaseService
      *
      * Example URL: /currency_exchange_rates
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -54,7 +54,7 @@ class CurrencyExchangeRatesService extends BaseService
      *
      * Example URL: /currency_exchange_rates
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/CustomerBankAccountsService.php
+++ b/lib/Services/CustomerBankAccountsService.php
@@ -18,11 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the CustomerBankAccount
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
- * @method disable()
+ * @method ListResponse list(array $params)
  */
 class CustomerBankAccountsService extends BaseService
 {
@@ -36,7 +32,7 @@ class CustomerBankAccountsService extends BaseService
      *
      * Example URL: /customer_bank_accounts
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return CustomerBankAccount
      **/
     public function create($params = array())
@@ -71,7 +67,7 @@ class CustomerBankAccountsService extends BaseService
      *
      * Example URL: /customer_bank_accounts
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -94,7 +90,7 @@ class CustomerBankAccountsService extends BaseService
      * Example URL: /customer_bank_accounts/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return CustomerBankAccount
      **/
     public function get($identity, $params = array())
@@ -123,7 +119,7 @@ class CustomerBankAccountsService extends BaseService
      * Example URL: /customer_bank_accounts/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "BA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return CustomerBankAccount
      **/
     public function update($identity, $params = array())
@@ -154,7 +150,7 @@ class CustomerBankAccountsService extends BaseService
      * Example URL: /customer_bank_accounts/:identity/actions/disable
      *
      * @param  string        $identity Unique identifier, beginning with "BA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return CustomerBankAccount
      **/
     public function disable($identity, $params = array())
@@ -195,7 +191,7 @@ class CustomerBankAccountsService extends BaseService
      *
      * Example URL: /customer_bank_accounts
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/CustomerNotificationsService.php
+++ b/lib/Services/CustomerNotificationsService.php
@@ -17,8 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the CustomerNotification
  * endpoints of the API
- *
- * @method handle()
  */
 class CustomerNotificationsService extends BaseService
 {
@@ -33,7 +31,7 @@ class CustomerNotificationsService extends BaseService
      * Example URL: /customer_notifications/:identity/actions/handle
      *
      * @param  string        $identity The id of the notification.
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return CustomerNotification
      **/
     public function handle($identity, $params = array())
@@ -41,19 +39,19 @@ class CustomerNotificationsService extends BaseService
         $path = Util::subUrl(
             '/customer_notifications/:identity/actions/handle',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->post($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/CustomersService.php
+++ b/lib/Services/CustomersService.php
@@ -18,11 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Customer
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
- * @method remove()
+ * @method ListResponse list(array $params)
  */
 class CustomersService extends BaseService
 {
@@ -36,7 +32,7 @@ class CustomersService extends BaseService
      *
      * Example URL: /customers
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Customer
      **/
     public function create($params = array())
@@ -71,7 +67,7 @@ class CustomersService extends BaseService
      *
      * Example URL: /customers
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -94,7 +90,7 @@ class CustomersService extends BaseService
      * Example URL: /customers/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "CU".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Customer
      **/
     public function get($identity, $params = array())
@@ -123,7 +119,7 @@ class CustomersService extends BaseService
      * Example URL: /customers/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "CU".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Customer
      **/
     public function update($identity, $params = array())
@@ -154,7 +150,7 @@ class CustomersService extends BaseService
      * Example URL: /customers/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "CU".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Customer
      **/
     public function remove($identity, $params = array())
@@ -182,7 +178,7 @@ class CustomersService extends BaseService
      *
      * Example URL: /customers
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/EventsService.php
+++ b/lib/Services/EventsService.php
@@ -18,8 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Event
  * endpoints of the API
  *
- * @method list()
- * @method get()
+ * @method ListResponse list(array $params)
  */
 class EventsService extends BaseService
 {
@@ -33,7 +32,7 @@ class EventsService extends BaseService
      *
      * Example URL: /events
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -56,7 +55,7 @@ class EventsService extends BaseService
      * Example URL: /events/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "EV".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Event
      **/
     public function get($identity, $params = array())
@@ -84,7 +83,7 @@ class EventsService extends BaseService
      *
      * Example URL: /events
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/InstalmentSchedulesService.php
+++ b/lib/Services/InstalmentSchedulesService.php
@@ -18,12 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the InstalmentSchedule
  * endpoints of the API
  *
- * @method createWithDates()
- * @method createWithSchedule()
- * @method list()
- * @method get()
- * @method update()
- * @method cancel()
+ * @method ListResponse list(array $params)
  */
 class InstalmentSchedulesService extends BaseService
 {
@@ -37,7 +32,7 @@ class InstalmentSchedulesService extends BaseService
      *
      * Example URL: /instalment_schedules
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return InstalmentSchedule
      **/
     public function createWithDates($params = array())
@@ -72,7 +67,7 @@ class InstalmentSchedulesService extends BaseService
      *
      * Example URL: /instalment_schedules
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return InstalmentSchedule
      **/
     public function createWithSchedule($params = array())
@@ -107,7 +102,7 @@ class InstalmentSchedulesService extends BaseService
      *
      * Example URL: /instalment_schedules
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -130,7 +125,7 @@ class InstalmentSchedulesService extends BaseService
      * Example URL: /instalment_schedules/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "IS".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return InstalmentSchedule
      **/
     public function get($identity, $params = array())
@@ -159,7 +154,7 @@ class InstalmentSchedulesService extends BaseService
      * Example URL: /instalment_schedules/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "IS".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return InstalmentSchedule
      **/
     public function update($identity, $params = array())
@@ -190,7 +185,7 @@ class InstalmentSchedulesService extends BaseService
      * Example URL: /instalment_schedules/:identity/actions/cancel
      *
      * @param  string        $identity Unique identifier, beginning with "IS".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return InstalmentSchedule
      **/
     public function cancel($identity, $params = array())
@@ -231,7 +226,7 @@ class InstalmentSchedulesService extends BaseService
      *
      * Example URL: /instalment_schedules
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/InstitutionsService.php
+++ b/lib/Services/InstitutionsService.php
@@ -18,8 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Institution
  * endpoints of the API
  *
- * @method list()
- * @method listForBillingRequest()
+ * @method ListResponse list(array $params)
  */
 class InstitutionsService extends BaseService
 {
@@ -33,7 +32,7 @@ class InstitutionsService extends BaseService
      *
      * Example URL: /institutions
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -56,7 +55,7 @@ class InstitutionsService extends BaseService
      * Example URL: /billing_requests/:identity/institutions
      *
      * @param  string        $identity Unique identifier, beginning with "BRQ".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return ListResponse
      **/
     public function listForBillingRequest($identity, $params = array())
@@ -84,7 +83,7 @@ class InstitutionsService extends BaseService
      *
      * Example URL: /institutions
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/MandateImportEntriesService.php
+++ b/lib/Services/MandateImportEntriesService.php
@@ -18,8 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the MandateImportEntry
  * endpoints of the API
  *
- * @method create()
- * @method list()
+ * @method ListResponse list(array $params)
  */
 class MandateImportEntriesService extends BaseService
 {
@@ -33,7 +32,7 @@ class MandateImportEntriesService extends BaseService
      *
      * Example URL: /mandate_import_entries
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return MandateImportEntry
      **/
     public function create($params = array())
@@ -57,7 +56,7 @@ class MandateImportEntriesService extends BaseService
      *
      * Example URL: /mandate_import_entries
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -79,7 +78,7 @@ class MandateImportEntriesService extends BaseService
      *
      * Example URL: /mandate_import_entries
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/MandateImportsService.php
+++ b/lib/Services/MandateImportsService.php
@@ -17,11 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the MandateImport
  * endpoints of the API
- *
- * @method create()
- * @method get()
- * @method submit()
- * @method cancel()
  */
 class MandateImportsService extends BaseService
 {
@@ -35,19 +30,19 @@ class MandateImportsService extends BaseService
      *
      * Example URL: /mandate_imports
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return MandateImport
      **/
     public function create($params = array())
     {
         $path = "/mandate_imports";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -60,7 +55,7 @@ class MandateImportsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -71,7 +66,7 @@ class MandateImportsService extends BaseService
      * Example URL: /mandate_imports/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "IM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return MandateImport
      **/
     public function get($identity, $params = array())
@@ -79,7 +74,7 @@ class MandateImportsService extends BaseService
         $path = Util::subUrl(
             '/mandate_imports/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -87,9 +82,9 @@ class MandateImportsService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -100,7 +95,7 @@ class MandateImportsService extends BaseService
      * Example URL: /mandate_imports/:identity/actions/submit
      *
      * @param  string        $identity Unique identifier, beginning with "IM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return MandateImport
      **/
     public function submit($identity, $params = array())
@@ -108,17 +103,17 @@ class MandateImportsService extends BaseService
         $path = Util::subUrl(
             '/mandate_imports/:identity/actions/submit',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -131,7 +126,7 @@ class MandateImportsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -142,7 +137,7 @@ class MandateImportsService extends BaseService
      * Example URL: /mandate_imports/:identity/actions/cancel
      *
      * @param  string        $identity Unique identifier, beginning with "IM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return MandateImport
      **/
     public function cancel($identity, $params = array())
@@ -150,17 +145,17 @@ class MandateImportsService extends BaseService
         $path = Util::subUrl(
             '/mandate_imports/:identity/actions/cancel',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -173,7 +168,7 @@ class MandateImportsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/MandatePdfsService.php
+++ b/lib/Services/MandatePdfsService.php
@@ -17,8 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the MandatePdf
  * endpoints of the API
- *
- * @method create()
  */
 class MandatePdfsService extends BaseService
 {
@@ -32,21 +30,21 @@ class MandatePdfsService extends BaseService
      *
      * Example URL: /mandate_pdfs
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return MandatePdf
      **/
     public function create($params = array())
     {
         $path = "/mandate_pdfs";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->post($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/MandatesService.php
+++ b/lib/Services/MandatesService.php
@@ -18,12 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Mandate
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
- * @method cancel()
- * @method reinstate()
+ * @method ListResponse list(array $params)
  */
 class MandatesService extends BaseService
 {
@@ -37,7 +32,7 @@ class MandatesService extends BaseService
      *
      * Example URL: /mandates
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Mandate
      **/
     public function create($params = array())
@@ -72,7 +67,7 @@ class MandatesService extends BaseService
      *
      * Example URL: /mandates
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -96,7 +91,7 @@ class MandatesService extends BaseService
      *
      * @param  string        $identity Unique identifier, beginning with "MD". Note that this
                                  prefix may not apply to mandates created before 2016.
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Mandate
      **/
     public function get($identity, $params = array())
@@ -126,7 +121,7 @@ class MandatesService extends BaseService
      *
      * @param  string        $identity Unique identifier, beginning with "MD". Note that this
                                  prefix may not apply to mandates created before 2016.
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Mandate
      **/
     public function update($identity, $params = array())
@@ -158,7 +153,7 @@ class MandatesService extends BaseService
      *
      * @param  string        $identity Unique identifier, beginning with "MD". Note that this
                                  prefix may not apply to mandates created before 2016.
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Mandate
      **/
     public function cancel($identity, $params = array())
@@ -201,7 +196,7 @@ class MandatesService extends BaseService
      *
      * @param  string        $identity Unique identifier, beginning with "MD". Note that this
                                  prefix may not apply to mandates created before 2016.
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Mandate
      **/
     public function reinstate($identity, $params = array())
@@ -242,7 +237,7 @@ class MandatesService extends BaseService
      *
      * Example URL: /mandates
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/NegativeBalanceLimitsService.php
+++ b/lib/Services/NegativeBalanceLimitsService.php
@@ -18,8 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the NegativeBalanceLimit
  * endpoints of the API
  *
- * @method list()
- * @method create()
+ * @method ListResponse list(array $params)
  */
 class NegativeBalanceLimitsService extends BaseService
 {
@@ -33,7 +32,7 @@ class NegativeBalanceLimitsService extends BaseService
      *
      * Example URL: /negative_balance_limits
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -55,7 +54,7 @@ class NegativeBalanceLimitsService extends BaseService
      *
      * Example URL: /negative_balance_limits
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return NegativeBalanceLimit
      **/
     public function create($params = array())
@@ -79,7 +78,7 @@ class NegativeBalanceLimitsService extends BaseService
      *
      * Example URL: /negative_balance_limits
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/PayerAuthorisationsService.php
+++ b/lib/Services/PayerAuthorisationsService.php
@@ -17,12 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the PayerAuthorisation
  * endpoints of the API
- *
- * @method get()
- * @method create()
- * @method update()
- * @method submit()
- * @method confirm()
  */
 class PayerAuthorisationsService extends BaseService
 {
@@ -37,7 +31,7 @@ class PayerAuthorisationsService extends BaseService
      * Example URL: /payer_authorisations/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "PA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return PayerAuthorisation
      **/
     public function get($identity, $params = array())
@@ -45,7 +39,7 @@ class PayerAuthorisationsService extends BaseService
         $path = Util::subUrl(
             '/payer_authorisations/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -53,9 +47,9 @@ class PayerAuthorisationsService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -65,19 +59,19 @@ class PayerAuthorisationsService extends BaseService
      *
      * Example URL: /payer_authorisations
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return PayerAuthorisation
      **/
     public function create($params = array())
     {
         $path = "/payer_authorisations";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -90,7 +84,7 @@ class PayerAuthorisationsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -101,7 +95,7 @@ class PayerAuthorisationsService extends BaseService
      * Example URL: /payer_authorisations/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "PA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return PayerAuthorisation
      **/
     public function update($identity, $params = array())
@@ -109,19 +103,19 @@ class PayerAuthorisationsService extends BaseService
         $path = Util::subUrl(
             '/payer_authorisations/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->put($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -132,7 +126,7 @@ class PayerAuthorisationsService extends BaseService
      * Example URL: /payer_authorisations/:identity/actions/submit
      *
      * @param  string        $identity Unique identifier, beginning with "PA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return PayerAuthorisation
      **/
     public function submit($identity, $params = array())
@@ -140,17 +134,17 @@ class PayerAuthorisationsService extends BaseService
         $path = Util::subUrl(
             '/payer_authorisations/:identity/actions/submit',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -163,7 +157,7 @@ class PayerAuthorisationsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -174,7 +168,7 @@ class PayerAuthorisationsService extends BaseService
      * Example URL: /payer_authorisations/:identity/actions/confirm
      *
      * @param  string        $identity Unique identifier, beginning with "PA".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return PayerAuthorisation
      **/
     public function confirm($identity, $params = array())
@@ -182,17 +176,17 @@ class PayerAuthorisationsService extends BaseService
         $path = Util::subUrl(
             '/payer_authorisations/:identity/actions/confirm',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -205,7 +199,7 @@ class PayerAuthorisationsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/PaymentsService.php
+++ b/lib/Services/PaymentsService.php
@@ -18,12 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Payment
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
- * @method cancel()
- * @method retry()
+ * @method ListResponse list(array $params)
  */
 class PaymentsService extends BaseService
 {
@@ -37,7 +32,7 @@ class PaymentsService extends BaseService
      *
      * Example URL: /payments
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Payment
      **/
     public function create($params = array())
@@ -72,7 +67,7 @@ class PaymentsService extends BaseService
      *
      * Example URL: /payments
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -95,7 +90,7 @@ class PaymentsService extends BaseService
      * Example URL: /payments/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "PM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Payment
      **/
     public function get($identity, $params = array())
@@ -124,7 +119,7 @@ class PaymentsService extends BaseService
      * Example URL: /payments/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "PM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Payment
      **/
     public function update($identity, $params = array())
@@ -155,7 +150,7 @@ class PaymentsService extends BaseService
      * Example URL: /payments/:identity/actions/cancel
      *
      * @param  string        $identity Unique identifier, beginning with "PM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Payment
      **/
     public function cancel($identity, $params = array())
@@ -197,7 +192,7 @@ class PaymentsService extends BaseService
      * Example URL: /payments/:identity/actions/retry
      *
      * @param  string        $identity Unique identifier, beginning with "PM".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Payment
      **/
     public function retry($identity, $params = array())
@@ -238,7 +233,7 @@ class PaymentsService extends BaseService
      *
      * Example URL: /payments
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/PayoutItemsService.php
+++ b/lib/Services/PayoutItemsService.php
@@ -18,7 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the PayoutItem
  * endpoints of the API
  *
- * @method list()
+ * @method ListResponse list(array $params)
  */
 class PayoutItemsService extends BaseService
 {
@@ -32,7 +32,7 @@ class PayoutItemsService extends BaseService
      *
      * Example URL: /payout_items
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -54,7 +54,7 @@ class PayoutItemsService extends BaseService
      *
      * Example URL: /payout_items
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/PayoutsService.php
+++ b/lib/Services/PayoutsService.php
@@ -18,9 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Payout
  * endpoints of the API
  *
- * @method list()
- * @method get()
- * @method update()
+ * @method ListResponse list(array $params)
  */
 class PayoutsService extends BaseService
 {
@@ -34,7 +32,7 @@ class PayoutsService extends BaseService
      *
      * Example URL: /payouts
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -57,7 +55,7 @@ class PayoutsService extends BaseService
      * Example URL: /payouts/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "PO".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Payout
      **/
     public function get($identity, $params = array())
@@ -86,7 +84,7 @@ class PayoutsService extends BaseService
      * Example URL: /payouts/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "PO".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Payout
      **/
     public function update($identity, $params = array())
@@ -116,7 +114,7 @@ class PayoutsService extends BaseService
      *
      * Example URL: /payouts
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/RedirectFlowsService.php
+++ b/lib/Services/RedirectFlowsService.php
@@ -17,10 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the RedirectFlow
  * endpoints of the API
- *
- * @method create()
- * @method get()
- * @method complete()
  */
 class RedirectFlowsService extends BaseService
 {
@@ -34,19 +30,19 @@ class RedirectFlowsService extends BaseService
      *
      * Example URL: /redirect_flows
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return RedirectFlow
      **/
     public function create($params = array())
     {
         $path = "/redirect_flows";
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array($this->envelope_key => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -59,7 +55,7 @@ class RedirectFlowsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -70,7 +66,7 @@ class RedirectFlowsService extends BaseService
      * Example URL: /redirect_flows/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "RE".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return RedirectFlow
      **/
     public function get($identity, $params = array())
@@ -78,7 +74,7 @@ class RedirectFlowsService extends BaseService
         $path = Util::subUrl(
             '/redirect_flows/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -86,9 +82,9 @@ class RedirectFlowsService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -99,7 +95,7 @@ class RedirectFlowsService extends BaseService
      * Example URL: /redirect_flows/:identity/actions/complete
      *
      * @param  string        $identity Unique identifier, beginning with "RE".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return RedirectFlow
      **/
     public function complete($identity, $params = array())
@@ -107,17 +103,17 @@ class RedirectFlowsService extends BaseService
         $path = Util::subUrl(
             '/redirect_flows/:identity/actions/complete',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -130,7 +126,7 @@ class RedirectFlowsService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/RefundsService.php
+++ b/lib/Services/RefundsService.php
@@ -18,10 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Refund
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
+ * @method ListResponse list(array $params)
  */
 class RefundsService extends BaseService
 {
@@ -35,7 +32,7 @@ class RefundsService extends BaseService
      *
      * Example URL: /refunds
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Refund
      **/
     public function create($params = array())
@@ -70,7 +67,7 @@ class RefundsService extends BaseService
      *
      * Example URL: /refunds
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -93,7 +90,7 @@ class RefundsService extends BaseService
      * Example URL: /refunds/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "RF".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Refund
      **/
     public function get($identity, $params = array())
@@ -122,7 +119,7 @@ class RefundsService extends BaseService
      * Example URL: /refunds/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "RF".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Refund
      **/
     public function update($identity, $params = array())
@@ -152,7 +149,7 @@ class RefundsService extends BaseService
      *
      * Example URL: /refunds
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/ScenarioSimulatorsService.php
+++ b/lib/Services/ScenarioSimulatorsService.php
@@ -17,7 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the ScenarioSimulator
  * endpoints of the API
- *  @method run()
  */
 class ScenarioSimulatorsService extends BaseService
 {
@@ -182,7 +181,7 @@ class ScenarioSimulatorsService extends BaseService
  except for `bank_authorisation`. Only billing requests with
  a `payment_request` are supported.</li>
  </ul>
-    * @param  string[mixed] $params An associative array for any params
+    * @param  array<string, mixed> $params An associative array for any params
     * @return ScenarioSimulator
     **/
     public function run($identity, $params = array())
@@ -190,19 +189,19 @@ class ScenarioSimulatorsService extends BaseService
         $path = Util::subUrl(
             '/scenario_simulators/:identity/actions/run',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
           $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
           unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->post($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/SchemeIdentifiersService.php
+++ b/lib/Services/SchemeIdentifiersService.php
@@ -18,9 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the SchemeIdentifier
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
+ * @method ListResponse list(array $params)
  */
 class SchemeIdentifiersService extends BaseService
 {
@@ -34,7 +32,7 @@ class SchemeIdentifiersService extends BaseService
      *
      * Example URL: /scheme_identifiers
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return SchemeIdentifier
      **/
     public function create($params = array())
@@ -69,7 +67,7 @@ class SchemeIdentifiersService extends BaseService
      *
      * Example URL: /scheme_identifiers
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -92,7 +90,7 @@ class SchemeIdentifiersService extends BaseService
      * Example URL: /scheme_identifiers/:identity
      *
      * @param  string        $identity Unique identifier, usually beginning with "SU".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return SchemeIdentifier
      **/
     public function get($identity, $params = array())
@@ -120,7 +118,7 @@ class SchemeIdentifiersService extends BaseService
      *
      * Example URL: /scheme_identifiers
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/SubscriptionsService.php
+++ b/lib/Services/SubscriptionsService.php
@@ -18,13 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Subscription
  * endpoints of the API
  *
- * @method create()
- * @method list()
- * @method get()
- * @method update()
- * @method pause()
- * @method resume()
- * @method cancel()
+ * @method ListResponse list(array $params)
  */
 class SubscriptionsService extends BaseService
 {
@@ -38,7 +32,7 @@ class SubscriptionsService extends BaseService
      *
      * Example URL: /subscriptions
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return Subscription
      **/
     public function create($params = array())
@@ -73,7 +67,7 @@ class SubscriptionsService extends BaseService
      *
      * Example URL: /subscriptions
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -96,7 +90,7 @@ class SubscriptionsService extends BaseService
      * Example URL: /subscriptions/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "SB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Subscription
      **/
     public function get($identity, $params = array())
@@ -125,7 +119,7 @@ class SubscriptionsService extends BaseService
      * Example URL: /subscriptions/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "SB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Subscription
      **/
     public function update($identity, $params = array())
@@ -156,7 +150,7 @@ class SubscriptionsService extends BaseService
      * Example URL: /subscriptions/:identity/actions/pause
      *
      * @param  string        $identity Unique identifier, beginning with "SB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Subscription
      **/
     public function pause($identity, $params = array())
@@ -198,7 +192,7 @@ class SubscriptionsService extends BaseService
      * Example URL: /subscriptions/:identity/actions/resume
      *
      * @param  string        $identity Unique identifier, beginning with "SB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Subscription
      **/
     public function resume($identity, $params = array())
@@ -240,7 +234,7 @@ class SubscriptionsService extends BaseService
      * Example URL: /subscriptions/:identity/actions/cancel
      *
      * @param  string        $identity Unique identifier, beginning with "SB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Subscription
      **/
     public function cancel($identity, $params = array())
@@ -281,7 +275,7 @@ class SubscriptionsService extends BaseService
      *
      * Example URL: /subscriptions
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/TaxRatesService.php
+++ b/lib/Services/TaxRatesService.php
@@ -18,8 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the TaxRate
  * endpoints of the API
  *
- * @method list()
- * @method get()
+ * @method ListResponse list(array $params)
  */
 class TaxRatesService extends BaseService
 {
@@ -33,7 +32,7 @@ class TaxRatesService extends BaseService
      *
      * Example URL: /tax_rates
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -57,7 +56,7 @@ class TaxRatesService extends BaseService
      *
      * @param  string        $identity The unique identifier created by the jurisdiction, tax type
                                  and version
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return TaxRate
      **/
     public function get($identity, $params = array())
@@ -85,7 +84,7 @@ class TaxRatesService extends BaseService
      *
      * Example URL: /tax_rates
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/TransferredMandatesService.php
+++ b/lib/Services/TransferredMandatesService.php
@@ -17,8 +17,6 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
 /**
  * Service that provides access to the TransferredMandate
  * endpoints of the API
- *
- * @method transferredMandates()
  */
 class TransferredMandatesService extends BaseService
 {
@@ -34,7 +32,7 @@ class TransferredMandatesService extends BaseService
      *
      * @param  string        $identity Unique identifier, beginning with "MD". Note that this
                                  prefix may not apply to mandates created before 2016.
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return TransferredMandate
      **/
     public function transferredMandates($identity, $params = array())
@@ -42,7 +40,7 @@ class TransferredMandatesService extends BaseService
         $path = Util::subUrl(
             '/transferred_mandates/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -50,9 +48,9 @@ class TransferredMandatesService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }

--- a/lib/Services/VerificationDetailsService.php
+++ b/lib/Services/VerificationDetailsService.php
@@ -18,8 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the VerificationDetail
  * endpoints of the API
  *
- * @method create()
- * @method list()
+ * @method ListResponse list(array $params)
  */
 class VerificationDetailsService extends BaseService
 {
@@ -33,7 +32,7 @@ class VerificationDetailsService extends BaseService
      *
      * Example URL: /verification_details
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return VerificationDetail
      **/
     public function create($params = array())
@@ -57,7 +56,7 @@ class VerificationDetailsService extends BaseService
      *
      * Example URL: /verification_details
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -79,7 +78,7 @@ class VerificationDetailsService extends BaseService
      *
      * Example URL: /verification_details
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())

--- a/lib/Services/WebhooksService.php
+++ b/lib/Services/WebhooksService.php
@@ -18,9 +18,7 @@ use \GoCardlessPro\Core\Exception\InvalidStateException;
  * Service that provides access to the Webhook
  * endpoints of the API
  *
- * @method list()
- * @method get()
- * @method retry()
+ * @method ListResponse list(array $params)
  */
 class WebhooksService extends BaseService
 {
@@ -34,7 +32,7 @@ class WebhooksService extends BaseService
      *
      * Example URL: /webhooks
      *
-     * @param  string[mixed] $params An associative array for any params
+     * @param  array<string, mixed> $params An associative array for any params
      * @return ListResponse
      **/
     protected function _doList($params = array())
@@ -44,9 +42,9 @@ class WebhooksService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -57,7 +55,7 @@ class WebhooksService extends BaseService
      * Example URL: /webhooks/:identity
      *
      * @param  string        $identity Unique identifier, beginning with "WB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Webhook
      **/
     public function get($identity, $params = array())
@@ -65,7 +63,7 @@ class WebhooksService extends BaseService
         $path = Util::subUrl(
             '/webhooks/:identity',
             array(
-                
+
                 'identity' => $identity
             )
         );
@@ -73,9 +71,9 @@ class WebhooksService extends BaseService
             unset($params['params']);
         }
 
-        
+
         $response = $this->api_client->get($path, $params);
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -86,7 +84,7 @@ class WebhooksService extends BaseService
      * Example URL: /webhooks/:identity/actions/retry
      *
      * @param  string        $identity Unique identifier, beginning with "WB".
-     * @param  string[mixed] $params   An associative array for any params
+     * @param  array<string, mixed> $params   An associative array for any params
      * @return Webhook
      **/
     public function retry($identity, $params = array())
@@ -94,17 +92,17 @@ class WebhooksService extends BaseService
         $path = Util::subUrl(
             '/webhooks/:identity/actions/retry',
             array(
-                
+
                 'identity' => $identity
             )
         );
-        if(isset($params['params'])) { 
+        if(isset($params['params'])) {
             $params['body'] = json_encode(array("data" => (object)$params['params']));
-        
+
             unset($params['params']);
         }
 
-        
+
         try {
             $response = $this->api_client->post($path, $params);
         } catch(InvalidStateException $e) {
@@ -117,7 +115,7 @@ class WebhooksService extends BaseService
 
             throw $e;
         }
-        
+
 
         return $this->getResourceForResponse($response);
     }
@@ -127,7 +125,7 @@ class WebhooksService extends BaseService
      *
      * Example URL: /webhooks
      *
-     * @param  string[mixed] $params
+     * @param  array<string, mixed> $params
      * @return Paginator
      **/
     public function all($params = array())


### PR DESCRIPTION
Hi,

This PR is doing multiple fixes:

1) Both
```
array[string][mixed] 
string[mixed]
```
are not valid PHPdoc and it reports error when using an IDE or a static-analysis tool like PHPStan
`array<string, mixed>` is the correct format.

Related issue => https://github.com/gocardless/gocardless-pro-php/issues/134

2) `@method` are not used correctly.

Cf https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/method.html
- The method tag is only used to add extra method which are generated by the `__call` method, so things like
```
 * @method create()
 * @method get()
```
is incorrect since those method are fully implemented in the classes.

- The method tag should precise the params and the return type, so things like
```
 * @method list()
```
is wrong, it should be
```
 * @method ListResponse list(array $params)
```

All of these changed are in files with the following warning
```
WARNING: Do not edit by hand, this file was generated by Crank:
```
but I do not have access in the `https://github.com/gocardless/crank`

Can anyone help me on this @barrucadu @Nimisoere @opsz2 @NickLewry ?