### PR TITLE
Fix property read syntax to supported by more tools

### DIFF
--- a/lib/Resources/BankAuthorisation.php
+++ b/lib/Resources/BankAuthorisation.php
@@ -11,16 +11,16 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a bank_authorisation, providing access to its
  * attributes
  *
- * @property-read $authorisation_type
- * @property-read $authorised_at
- * @property-read $created_at
- * @property-read $expires_at
- * @property-read $id
- * @property-read $last_visited_at
- * @property-read $links
- * @property-read $qr_code_url
- * @property-read $redirect_uri
- * @property-read $url
+ * @property-read mixed $authorisation_type
+ * @property-read mixed $authorised_at
+ * @property-read mixed $created_at
+ * @property-read mixed $expires_at
+ * @property-read mixed $id
+ * @property-read mixed $last_visited_at
+ * @property-read mixed $links
+ * @property-read mixed $qr_code_url
+ * @property-read mixed $redirect_uri
+ * @property-read mixed $url
  */
 class BankAuthorisation extends BaseResource
 {

--- a/lib/Resources/BankDetailsLookup.php
+++ b/lib/Resources/BankDetailsLookup.php
@@ -11,9 +11,9 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a bank_details_lookup, providing access to its
  * attributes
  *
- * @property-read $available_debit_schemes
- * @property-read $bank_name
- * @property-read $bic
+ * @property-read mixed $available_debit_schemes
+ * @property-read mixed $bank_name
+ * @property-read mixed $bic
  */
 class BankDetailsLookup extends BaseResource
 {

--- a/lib/Resources/BillingRequest.php
+++ b/lib/Resources/BillingRequest.php
@@ -11,17 +11,17 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a billing_request, providing access to its
  * attributes
  *
- * @property-read $actions
- * @property-read $created_at
- * @property-read $fallback_enabled
- * @property-read $id
- * @property-read $links
- * @property-read $mandate_request
- * @property-read $metadata
- * @property-read $payment_request
- * @property-read $purpose_code
- * @property-read $resources
- * @property-read $status
+ * @property-read mixed $actions
+ * @property-read mixed $created_at
+ * @property-read mixed $fallback_enabled
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $mandate_request
+ * @property-read mixed $metadata
+ * @property-read mixed $payment_request
+ * @property-read mixed $purpose_code
+ * @property-read mixed $resources
+ * @property-read mixed $status
  */
 class BillingRequest extends BaseResource
 {

--- a/lib/Resources/BillingRequestFlow.php
+++ b/lib/Resources/BillingRequestFlow.php
@@ -11,24 +11,24 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a billing_request_flow, providing access to its
  * attributes
  *
- * @property-read $authorisation_url
- * @property-read $auto_fulfil
- * @property-read $created_at
- * @property-read $customer_details_captured
- * @property-read $exit_uri
- * @property-read $expires_at
- * @property-read $id
- * @property-read $language
- * @property-read $links
- * @property-read $lock_bank_account
- * @property-read $lock_currency
- * @property-read $lock_customer_details
- * @property-read $prefilled_bank_account
- * @property-read $prefilled_customer
- * @property-read $redirect_uri
- * @property-read $session_token
- * @property-read $show_redirect_buttons
- * @property-read $show_success_redirect_button
+ * @property-read mixed $authorisation_url
+ * @property-read mixed $auto_fulfil
+ * @property-read mixed $created_at
+ * @property-read mixed $customer_details_captured
+ * @property-read mixed $exit_uri
+ * @property-read mixed $expires_at
+ * @property-read mixed $id
+ * @property-read mixed $language
+ * @property-read mixed $links
+ * @property-read mixed $lock_bank_account
+ * @property-read mixed $lock_currency
+ * @property-read mixed $lock_customer_details
+ * @property-read mixed $prefilled_bank_account
+ * @property-read mixed $prefilled_customer
+ * @property-read mixed $redirect_uri
+ * @property-read mixed $session_token
+ * @property-read mixed $show_redirect_buttons
+ * @property-read mixed $show_success_redirect_button
  */
 class BillingRequestFlow extends BaseResource
 {

--- a/lib/Resources/BillingRequestTemplate.php
+++ b/lib/Resources/BillingRequestTemplate.php
@@ -11,23 +11,23 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a billing_request_template, providing access to its
  * attributes
  *
- * @property-read $authorisation_url
- * @property-read $created_at
- * @property-read $id
- * @property-read $mandate_request_currency
- * @property-read $mandate_request_description
- * @property-read $mandate_request_metadata
- * @property-read $mandate_request_scheme
- * @property-read $mandate_request_verify
- * @property-read $metadata
- * @property-read $name
- * @property-read $payment_request_amount
- * @property-read $payment_request_currency
- * @property-read $payment_request_description
- * @property-read $payment_request_metadata
- * @property-read $payment_request_scheme
- * @property-read $redirect_uri
- * @property-read $updated_at
+ * @property-read mixed $authorisation_url
+ * @property-read mixed $created_at
+ * @property-read mixed $id
+ * @property-read mixed $mandate_request_currency
+ * @property-read mixed $mandate_request_description
+ * @property-read mixed $mandate_request_metadata
+ * @property-read mixed $mandate_request_scheme
+ * @property-read mixed $mandate_request_verify
+ * @property-read mixed $metadata
+ * @property-read mixed $name
+ * @property-read mixed $payment_request_amount
+ * @property-read mixed $payment_request_currency
+ * @property-read mixed $payment_request_description
+ * @property-read mixed $payment_request_metadata
+ * @property-read mixed $payment_request_scheme
+ * @property-read mixed $redirect_uri
+ * @property-read mixed $updated_at
  */
 class BillingRequestTemplate extends BaseResource
 {

--- a/lib/Resources/Block.php
+++ b/lib/Resources/Block.php
@@ -11,14 +11,14 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a block, providing access to its
  * attributes
  *
- * @property-read $active
- * @property-read $block_type
- * @property-read $created_at
- * @property-read $id
- * @property-read $reason_description
- * @property-read $reason_type
- * @property-read $resource_reference
- * @property-read $updated_at
+ * @property-read mixed $active
+ * @property-read mixed $block_type
+ * @property-read mixed $created_at
+ * @property-read mixed $id
+ * @property-read mixed $reason_description
+ * @property-read mixed $reason_type
+ * @property-read mixed $resource_reference
+ * @property-read mixed $updated_at
  */
 class Block extends BaseResource
 {

--- a/lib/Resources/Creditor.php
+++ b/lib/Resources/Creditor.php
@@ -11,27 +11,27 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a creditor, providing access to its
  * attributes
  *
- * @property-read $address_line1
- * @property-read $address_line2
- * @property-read $address_line3
- * @property-read $bank_reference_prefix
- * @property-read $can_create_refunds
- * @property-read $city
- * @property-read $country_code
- * @property-read $created_at
- * @property-read $creditor_type
- * @property-read $custom_payment_pages_enabled
- * @property-read $fx_payout_currency
- * @property-read $id
- * @property-read $links
- * @property-read $logo_url
- * @property-read $mandate_imports_enabled
- * @property-read $merchant_responsible_for_notifications
- * @property-read $name
- * @property-read $postal_code
- * @property-read $region
- * @property-read $scheme_identifiers
- * @property-read $verification_status
+ * @property-read mixed $address_line1
+ * @property-read mixed $address_line2
+ * @property-read mixed $address_line3
+ * @property-read mixed $bank_reference_prefix
+ * @property-read mixed $can_create_refunds
+ * @property-read mixed $city
+ * @property-read mixed $country_code
+ * @property-read mixed $created_at
+ * @property-read mixed $creditor_type
+ * @property-read mixed $custom_payment_pages_enabled
+ * @property-read mixed $fx_payout_currency
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $logo_url
+ * @property-read mixed $mandate_imports_enabled
+ * @property-read mixed $merchant_responsible_for_notifications
+ * @property-read mixed $name
+ * @property-read mixed $postal_code
+ * @property-read mixed $region
+ * @property-read mixed $scheme_identifiers
+ * @property-read mixed $verification_status
  */
 class Creditor extends BaseResource
 {

--- a/lib/Resources/CreditorBankAccount.php
+++ b/lib/Resources/CreditorBankAccount.php
@@ -11,18 +11,18 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a creditor_bank_account, providing access to its
  * attributes
  *
- * @property-read $account_holder_name
- * @property-read $account_number_ending
- * @property-read $account_type
- * @property-read $bank_name
- * @property-read $country_code
- * @property-read $created_at
- * @property-read $currency
- * @property-read $enabled
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $verification_status
+ * @property-read mixed $account_holder_name
+ * @property-read mixed $account_number_ending
+ * @property-read mixed $account_type
+ * @property-read mixed $bank_name
+ * @property-read mixed $country_code
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $enabled
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $verification_status
  */
 class CreditorBankAccount extends BaseResource
 {

--- a/lib/Resources/CurrencyExchangeRate.php
+++ b/lib/Resources/CurrencyExchangeRate.php
@@ -11,10 +11,10 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a currency_exchange_rate, providing access to its
  * attributes
  *
- * @property-read $rate
- * @property-read $source
- * @property-read $target
- * @property-read $time
+ * @property-read mixed $rate
+ * @property-read mixed $source
+ * @property-read mixed $target
+ * @property-read mixed $time
  */
 class CurrencyExchangeRate extends BaseResource
 {

--- a/lib/Resources/Customer.php
+++ b/lib/Resources/Customer.php
@@ -11,24 +11,24 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a customer, providing access to its
  * attributes
  *
- * @property-read $address_line1
- * @property-read $address_line2
- * @property-read $address_line3
- * @property-read $city
- * @property-read $company_name
- * @property-read $country_code
- * @property-read $created_at
- * @property-read $danish_identity_number
- * @property-read $email
- * @property-read $family_name
- * @property-read $given_name
- * @property-read $id
- * @property-read $language
- * @property-read $metadata
- * @property-read $phone_number
- * @property-read $postal_code
- * @property-read $region
- * @property-read $swedish_identity_number
+ * @property-read mixed $address_line1
+ * @property-read mixed $address_line2
+ * @property-read mixed $address_line3
+ * @property-read mixed $city
+ * @property-read mixed $company_name
+ * @property-read mixed $country_code
+ * @property-read mixed $created_at
+ * @property-read mixed $danish_identity_number
+ * @property-read mixed $email
+ * @property-read mixed $family_name
+ * @property-read mixed $given_name
+ * @property-read mixed $id
+ * @property-read mixed $language
+ * @property-read mixed $metadata
+ * @property-read mixed $phone_number
+ * @property-read mixed $postal_code
+ * @property-read mixed $region
+ * @property-read mixed $swedish_identity_number
  */
 class Customer extends BaseResource
 {

--- a/lib/Resources/CustomerBankAccount.php
+++ b/lib/Resources/CustomerBankAccount.php
@@ -11,17 +11,17 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a customer_bank_account, providing access to its
  * attributes
  *
- * @property-read $account_holder_name
- * @property-read $account_number_ending
- * @property-read $account_type
- * @property-read $bank_name
- * @property-read $country_code
- * @property-read $created_at
- * @property-read $currency
- * @property-read $enabled
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
+ * @property-read mixed $account_holder_name
+ * @property-read mixed $account_number_ending
+ * @property-read mixed $account_type
+ * @property-read mixed $bank_name
+ * @property-read mixed $country_code
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $enabled
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
  */
 class CustomerBankAccount extends BaseResource
 {

--- a/lib/Resources/CustomerNotification.php
+++ b/lib/Resources/CustomerNotification.php
@@ -11,12 +11,12 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a customer_notification, providing access to its
  * attributes
  *
- * @property-read $action_taken
- * @property-read $action_taken_at
- * @property-read $action_taken_by
- * @property-read $id
- * @property-read $links
- * @property-read $type
+ * @property-read mixed $action_taken
+ * @property-read mixed $action_taken_at
+ * @property-read mixed $action_taken_by
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $type
  */
 class CustomerNotification extends BaseResource
 {

--- a/lib/Resources/Event.php
+++ b/lib/Resources/Event.php
@@ -11,15 +11,15 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a event, providing access to its
  * attributes
  *
- * @property-read $action
- * @property-read $created_at
- * @property-read $customer_notifications
- * @property-read $details
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $resource_metadata
- * @property-read $resource_type
+ * @property-read mixed $action
+ * @property-read mixed $created_at
+ * @property-read mixed $customer_notifications
+ * @property-read mixed $details
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $resource_metadata
+ * @property-read mixed $resource_type
  */
 class Event extends BaseResource
 {

--- a/lib/Resources/InstalmentSchedule.php
+++ b/lib/Resources/InstalmentSchedule.php
@@ -11,15 +11,15 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a instalment_schedule, providing access to its
  * attributes
  *
- * @property-read $created_at
- * @property-read $currency
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $name
- * @property-read $payment_errors
- * @property-read $status
- * @property-read $total_amount
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $name
+ * @property-read mixed $payment_errors
+ * @property-read mixed $status
+ * @property-read mixed $total_amount
  */
 class InstalmentSchedule extends BaseResource
 {

--- a/lib/Resources/Institution.php
+++ b/lib/Resources/Institution.php
@@ -11,12 +11,12 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a institution, providing access to its
  * attributes
  *
- * @property-read $autocompletes_collect_bank_account
- * @property-read $country_code
- * @property-read $icon_url
- * @property-read $id
- * @property-read $logo_url
- * @property-read $name
+ * @property-read mixed $autocompletes_collect_bank_account
+ * @property-read mixed $country_code
+ * @property-read mixed $icon_url
+ * @property-read mixed $id
+ * @property-read mixed $logo_url
+ * @property-read mixed $name
  */
 class Institution extends BaseResource
 {

--- a/lib/Resources/Mandate.php
+++ b/lib/Resources/Mandate.php
@@ -11,20 +11,20 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a mandate, providing access to its
  * attributes
  *
- * @property-read $authorisation_source
- * @property-read $consent_parameters
- * @property-read $created_at
- * @property-read $funds_settlement
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $next_possible_charge_date
- * @property-read $next_possible_standard_ach_charge_date
- * @property-read $payments_require_approval
- * @property-read $reference
- * @property-read $scheme
- * @property-read $status
- * @property-read $verified_at
+ * @property-read mixed $authorisation_source
+ * @property-read mixed $consent_parameters
+ * @property-read mixed $created_at
+ * @property-read mixed $funds_settlement
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $next_possible_charge_date
+ * @property-read mixed $next_possible_standard_ach_charge_date
+ * @property-read mixed $payments_require_approval
+ * @property-read mixed $reference
+ * @property-read mixed $scheme
+ * @property-read mixed $status
+ * @property-read mixed $verified_at
  */
 class Mandate extends BaseResource
 {

--- a/lib/Resources/MandateImport.php
+++ b/lib/Resources/MandateImport.php
@@ -11,11 +11,11 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a mandate_import, providing access to its
  * attributes
  *
- * @property-read $created_at
- * @property-read $id
- * @property-read $links
- * @property-read $scheme
- * @property-read $status
+ * @property-read mixed $created_at
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $scheme
+ * @property-read mixed $status
  */
 class MandateImport extends BaseResource
 {

--- a/lib/Resources/MandateImportEntry.php
+++ b/lib/Resources/MandateImportEntry.php
@@ -11,9 +11,9 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a mandate_import_entry, providing access to its
  * attributes
  *
- * @property-read $created_at
- * @property-read $links
- * @property-read $record_identifier
+ * @property-read mixed $created_at
+ * @property-read mixed $links
+ * @property-read mixed $record_identifier
  */
 class MandateImportEntry extends BaseResource
 {

--- a/lib/Resources/MandatePdf.php
+++ b/lib/Resources/MandatePdf.php
@@ -11,8 +11,8 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a mandate_pdf, providing access to its
  * attributes
  *
- * @property-read $expires_at
- * @property-read $url
+ * @property-read mixed $expires_at
+ * @property-read mixed $url
  */
 class MandatePdf extends BaseResource
 {

--- a/lib/Resources/MandateRequestConstraints.php
+++ b/lib/Resources/MandateRequestConstraints.php
@@ -11,10 +11,10 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a mandate_request_constraints, providing access to its
  * attributes
  *
- * @property-read $end_date
- * @property-read $max_amount_per_payment
- * @property-read $periodic_limits
- * @property-read $start_date
+ * @property-read mixed $end_date
+ * @property-read mixed $max_amount_per_payment
+ * @property-read mixed $periodic_limits
+ * @property-read mixed $start_date
  */
 class MandateRequestConstraints extends BaseResource
 {

--- a/lib/Resources/NegativeBalanceLimit.php
+++ b/lib/Resources/NegativeBalanceLimit.php
@@ -11,11 +11,11 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a negative_balance_limit, providing access to its
  * attributes
  *
- * @property-read $balance_limit
- * @property-read $created_at
- * @property-read $currency
- * @property-read $id
- * @property-read $links
+ * @property-read mixed $balance_limit
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $id
+ * @property-read mixed $links
  */
 class NegativeBalanceLimit extends BaseResource
 {

--- a/lib/Resources/PayerAuthorisation.php
+++ b/lib/Resources/PayerAuthorisation.php
@@ -11,14 +11,14 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a payer_authorisation, providing access to its
  * attributes
  *
- * @property-read $bank_account
- * @property-read $created_at
- * @property-read $customer
- * @property-read $id
- * @property-read $incomplete_fields
- * @property-read $links
- * @property-read $mandate
- * @property-read $status
+ * @property-read mixed $bank_account
+ * @property-read mixed $created_at
+ * @property-read mixed $customer
+ * @property-read mixed $id
+ * @property-read mixed $incomplete_fields
+ * @property-read mixed $links
+ * @property-read mixed $mandate
+ * @property-read mixed $status
  */
 class PayerAuthorisation extends BaseResource
 {

--- a/lib/Resources/Payment.php
+++ b/lib/Resources/Payment.php
@@ -11,20 +11,20 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a payment, providing access to its
  * attributes
  *
- * @property-read $amount
- * @property-read $amount_refunded
- * @property-read $charge_date
- * @property-read $created_at
- * @property-read $currency
- * @property-read $description
- * @property-read $faster_ach
- * @property-read $fx
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $reference
- * @property-read $retry_if_possible
- * @property-read $status
+ * @property-read mixed $amount
+ * @property-read mixed $amount_refunded
+ * @property-read mixed $charge_date
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $description
+ * @property-read mixed $faster_ach
+ * @property-read mixed $fx
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $reference
+ * @property-read mixed $retry_if_possible
+ * @property-read mixed $status
  */
 class Payment extends BaseResource
 {

--- a/lib/Resources/Payout.php
+++ b/lib/Resources/Payout.php
@@ -11,19 +11,19 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a payout, providing access to its
  * attributes
  *
- * @property-read $amount
- * @property-read $arrival_date
- * @property-read $created_at
- * @property-read $currency
- * @property-read $deducted_fees
- * @property-read $fx
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $payout_type
- * @property-read $reference
- * @property-read $status
- * @property-read $tax_currency
+ * @property-read mixed $amount
+ * @property-read mixed $arrival_date
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $deducted_fees
+ * @property-read mixed $fx
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $payout_type
+ * @property-read mixed $reference
+ * @property-read mixed $status
+ * @property-read mixed $tax_currency
  */
 class Payout extends BaseResource
 {

--- a/lib/Resources/PayoutItem.php
+++ b/lib/Resources/PayoutItem.php
@@ -11,10 +11,10 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a payout_item, providing access to its
  * attributes
  *
- * @property-read $amount
- * @property-read $links
- * @property-read $taxes
- * @property-read $type
+ * @property-read mixed $amount
+ * @property-read mixed $links
+ * @property-read mixed $taxes
+ * @property-read mixed $type
  */
 class PayoutItem extends BaseResource
 {

--- a/lib/Resources/RedirectFlow.php
+++ b/lib/Resources/RedirectFlow.php
@@ -11,17 +11,17 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a redirect_flow, providing access to its
  * attributes
  *
- * @property-read $confirmation_url
- * @property-read $created_at
- * @property-read $description
- * @property-read $id
- * @property-read $links
- * @property-read $mandate_reference
- * @property-read $metadata
- * @property-read $redirect_url
- * @property-read $scheme
- * @property-read $session_token
- * @property-read $success_redirect_url
+ * @property-read mixed $confirmation_url
+ * @property-read mixed $created_at
+ * @property-read mixed $description
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $mandate_reference
+ * @property-read mixed $metadata
+ * @property-read mixed $redirect_url
+ * @property-read mixed $scheme
+ * @property-read mixed $session_token
+ * @property-read mixed $success_redirect_url
  */
 class RedirectFlow extends BaseResource
 {

--- a/lib/Resources/Refund.php
+++ b/lib/Resources/Refund.php
@@ -11,15 +11,15 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a refund, providing access to its
  * attributes
  *
- * @property-read $amount
- * @property-read $created_at
- * @property-read $currency
- * @property-read $fx
- * @property-read $id
- * @property-read $links
- * @property-read $metadata
- * @property-read $reference
- * @property-read $status
+ * @property-read mixed $amount
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $fx
+ * @property-read mixed $id
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $reference
+ * @property-read mixed $status
  */
 class Refund extends BaseResource
 {

--- a/lib/Resources/ScenarioSimulator.php
+++ b/lib/Resources/ScenarioSimulator.php
@@ -11,7 +11,7 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a scenario_simulator, providing access to its
  * attributes
  *
- * @property-read $id
+ * @property-read mixed $id
  */
 class ScenarioSimulator extends BaseResource
 {

--- a/lib/Resources/SchemeIdentifier.php
+++ b/lib/Resources/SchemeIdentifier.php
@@ -11,24 +11,24 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a scheme_identifier, providing access to its
  * attributes
  *
- * @property-read $address_line1
- * @property-read $address_line2
- * @property-read $address_line3
- * @property-read $can_specify_mandate_reference
- * @property-read $city
- * @property-read $country_code
- * @property-read $created_at
- * @property-read $currency
- * @property-read $email
- * @property-read $id
- * @property-read $minimum_advance_notice
- * @property-read $name
- * @property-read $phone_number
- * @property-read $postal_code
- * @property-read $reference
- * @property-read $region
- * @property-read $scheme
- * @property-read $status
+ * @property-read mixed $address_line1
+ * @property-read mixed $address_line2
+ * @property-read mixed $address_line3
+ * @property-read mixed $can_specify_mandate_reference
+ * @property-read mixed $city
+ * @property-read mixed $country_code
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $email
+ * @property-read mixed $id
+ * @property-read mixed $minimum_advance_notice
+ * @property-read mixed $name
+ * @property-read mixed $phone_number
+ * @property-read mixed $postal_code
+ * @property-read mixed $reference
+ * @property-read mixed $region
+ * @property-read mixed $scheme
+ * @property-read mixed $status
  */
 class SchemeIdentifier extends BaseResource
 {

--- a/lib/Resources/Subscription.php
+++ b/lib/Resources/Subscription.php
@@ -11,27 +11,27 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a subscription, providing access to its
  * attributes
  *
- * @property-read $amount
- * @property-read $app_fee
- * @property-read $count
- * @property-read $created_at
- * @property-read $currency
- * @property-read $day_of_month
- * @property-read $earliest_charge_date_after_resume
- * @property-read $end_date
- * @property-read $id
- * @property-read $interval
- * @property-read $interval_unit
- * @property-read $links
- * @property-read $metadata
- * @property-read $month
- * @property-read $name
- * @property-read $parent_plan_paused
- * @property-read $payment_reference
- * @property-read $retry_if_possible
- * @property-read $start_date
- * @property-read $status
- * @property-read $upcoming_payments
+ * @property-read mixed $amount
+ * @property-read mixed $app_fee
+ * @property-read mixed $count
+ * @property-read mixed $created_at
+ * @property-read mixed $currency
+ * @property-read mixed $day_of_month
+ * @property-read mixed $earliest_charge_date_after_resume
+ * @property-read mixed $end_date
+ * @property-read mixed $id
+ * @property-read mixed $interval
+ * @property-read mixed $interval_unit
+ * @property-read mixed $links
+ * @property-read mixed $metadata
+ * @property-read mixed $month
+ * @property-read mixed $name
+ * @property-read mixed $parent_plan_paused
+ * @property-read mixed $payment_reference
+ * @property-read mixed $retry_if_possible
+ * @property-read mixed $start_date
+ * @property-read mixed $status
+ * @property-read mixed $upcoming_payments
  */
 class Subscription extends BaseResource
 {
@@ -113,7 +113,7 @@ class Subscription extends BaseResource
     protected $interval_unit;
 
     /**
-     * 
+     *
      */
     protected $links;
 

--- a/lib/Resources/TaxRate.php
+++ b/lib/Resources/TaxRate.php
@@ -11,12 +11,12 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a tax_rate, providing access to its
  * attributes
  *
- * @property-read $end_date
- * @property-read $id
- * @property-read $jurisdiction
- * @property-read $percentage
- * @property-read $start_date
- * @property-read $type
+ * @property-read mixed $end_date
+ * @property-read mixed $id
+ * @property-read mixed $jurisdiction
+ * @property-read mixed $percentage
+ * @property-read mixed $start_date
+ * @property-read mixed $type
  */
 class TaxRate extends BaseResource
 {

--- a/lib/Resources/TransferredMandate.php
+++ b/lib/Resources/TransferredMandate.php
@@ -11,10 +11,10 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a transferred_mandate, providing access to its
  * attributes
  *
- * @property-read $encrypted_customer_bank_details
- * @property-read $encrypted_decryption_key
- * @property-read $links
- * @property-read $public_key_id
+ * @property-read mixed $encrypted_customer_bank_details
+ * @property-read mixed $encrypted_decryption_key
+ * @property-read mixed $links
+ * @property-read mixed $public_key_id
  */
 class TransferredMandate extends BaseResource
 {

--- a/lib/Resources/VerificationDetail.php
+++ b/lib/Resources/VerificationDetail.php
@@ -11,16 +11,16 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a verification_detail, providing access to its
  * attributes
  *
- * @property-read $address_line1
- * @property-read $address_line2
- * @property-read $address_line3
- * @property-read $city
- * @property-read $company_number
- * @property-read $description
- * @property-read $directors
- * @property-read $links
- * @property-read $name
- * @property-read $postal_code
+ * @property-read mixed $address_line1
+ * @property-read mixed $address_line2
+ * @property-read mixed $address_line3
+ * @property-read mixed $city
+ * @property-read mixed $company_number
+ * @property-read mixed $description
+ * @property-read mixed $directors
+ * @property-read mixed $links
+ * @property-read mixed $name
+ * @property-read mixed $postal_code
  */
 class VerificationDetail extends BaseResource
 {

--- a/lib/Resources/Webhook.php
+++ b/lib/Resources/Webhook.php
@@ -11,19 +11,19 @@ namespace GoCardlessPro\Resources;
  * A thin wrapper around a webhook, providing access to its
  * attributes
  *
- * @property-read $created_at
- * @property-read $id
- * @property-read $is_test
- * @property-read $request_body
- * @property-read $request_headers
- * @property-read $response_body
- * @property-read $response_body_truncated
- * @property-read $response_code
- * @property-read $response_headers
- * @property-read $response_headers_content_truncated
- * @property-read $response_headers_count_truncated
- * @property-read $successful
- * @property-read $url
+ * @property-read mixed $created_at
+ * @property-read mixed $id
+ * @property-read mixed $is_test
+ * @property-read mixed $request_body
+ * @property-read mixed $request_headers
+ * @property-read mixed $response_body
+ * @property-read mixed $response_body_truncated
+ * @property-read mixed $response_code
+ * @property-read mixed $response_headers
+ * @property-read mixed $response_headers_content_truncated
+ * @property-read mixed $response_headers_count_truncated
+ * @property-read mixed $successful
+ * @property-read mixed $url
  */
 class Webhook extends BaseResource
 {


### PR DESCRIPTION
Hi,

This PR is kinda similar to https://github.com/gocardless/gocardless-pro-php/pull/186 in the idea

The issue I encountered is that the syntax
```
@property-read $foo
```
is not a valid one for lot of PHPtool, and
```
@property-read TYPE $foo
```
should be preferred instead.

Since none of the property are typed in this lib, 
```
@property-read mixed $foo
```
does the job.

As an example,
- all the example by phpdocumentor have typed https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/property.html
- PHPStan fails on https://phpstan.org/r/2534dcd1-fb4e-47af-80f2-1d2f896ec6aa but not on https://phpstan.org/r/6da7b153-e2c3-46f9-a5d4-7f241436e7b7

In the same way, all this files are generated by crank, so I cannot contribute to them.
Is there a way to have acces to crank or that someone move this fix to the crank library @barrucadu @Nimisoere @opsz2 @NickLewry ?

Thanks