### PR TITLE
Add pull_request trigger and all-tests-passed aggregator job to CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: build
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   test_library:
@@ -16,3 +20,16 @@ jobs:
       - run: composer install --no-interaction
       - name: Test Library
         run: ./vendor/phpunit/phpunit/phpunit
+
+  all-tests-passed:
+    name: All tests passed
+    runs-on: ubuntu-latest
+    needs: [test_library]
+    if: always()
+    steps:
+      - name: Check test_library job status
+        run: |
+          if [ "${{ needs.test_library.result }}" != "success" ]; then
+            echo "test_library job did not succeed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a `pull_request` trigger alongside the existing `push` trigger so tests run against fork PRs, not just pushes to the repo.
- Restricts the `push` trigger to `master` only.
- Adds an `all-tests-passed` job that depends on the whole `test_library` matrix (PHP 8.2-8.5) and fails if any entry didn't succeed.

## Why
Part of IX-2323: setting up required status checks across GoCardless's public client library repos so we can safely enable auto-merge. A push-only trigger never runs against a fork PR's head commit, and the `test_library` matrix produces one check per PHP version - brittle to require individually since the list shifts whenever a version is added or dropped. `all-tests-passed` gives branch protection a single stable, fork-compatible check name to require.

## Test plan
- [x] Confirm `all-tests-passed` appears and passes on this PR