### PR TITLE
Fix release notes shell injection in create_release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -72,7 +72,6 @@ jobs:
           TAG="v${{ steps.version.outputs.version }}"
           git tag "$TAG"
           git push origin "$TAG"
-          NOTES="${{ steps.notes.outputs.notes }}"
           if [ -n "$(echo "$NOTES" | tr -d '[:space:]')" ]; then
             gh release create "$TAG" --title "$TAG" --notes "$NOTES"
           else
@@ -80,3 +79,4 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GOCARDLESS_CI_ROBOT_TOKEN }}
+          NOTES: ${{ steps.notes.outputs.notes }}


### PR DESCRIPTION
## Summary
- Changelog entries containing backticks (e.g. `` `resource_type: x` ``) were interpolated directly into a double-quoted bash string in the release step, causing bash to treat the backticks as command substitution instead of literal text.
- Fixes this by passing the notes via the step's `env:` context instead, so the value is expanded as a shell variable rather than re-parsed as script text.

Same fix as [gocardless/gocardless-pro-python#146](https://github.com/gocardless/gocardless-pro-python/pull/146), which hit this in production when a v3.7.0 changelog entry contained backticked code.

## Test plan
- [x] Reproduced the original failure locally with the affected changelog text and confirmed the old pattern fails identically
- [x] Confirmed the new pattern preserves the notes text literally with no shell execution
